### PR TITLE
ci: Add npm publish workflow for releases

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -2,7 +2,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -1,0 +1,30 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  release:
-    types: [published]
 
 jobs:
   build:
@@ -38,7 +36,6 @@ jobs:
     - name: Check package.json scripts
       run: npm run || echo "No npm scripts defined"
     
-    # 构建 TypeScript 项目（如果有 tsconfig.json）
     - name: Check for TypeScript
       run: |
         if [ -f tsconfig.json ]; then
@@ -48,7 +45,6 @@ jobs:
           echo "No TypeScript config found"
         fi
     
-    # 尝试构建，如果有 tsconfig.json 则使用 tsc
     - name: Build
       run: |
         if [ -f tsconfig.json ]; then
@@ -57,11 +53,3 @@ jobs:
           npm run build --if-present
         fi
     
-    # 如果有 test 脚本则运行测试
-    - name: Test (if exists)
-      run: |
-        if [ -f package.json ] && grep -q '"test"' package.json; then
-          npm test
-        else
-          echo "No test script found, skipping tests"
-        fi

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Alin-sky/koishi-plugin-ba-plugin.git"
+    "url": "git+https://github.com/AL-1S-QQBOT/koishi-plugin-ba-plugin.git"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary by Sourcery

更新用于 Node.js 构建和包发布的 CI 工作流，并修正仓库 URL 元数据。

增强功能：
- 将 `package.json` 中的 `repository` URL 更新为指向新的 GitHub 仓库位置。

构建：
- 调整主 Node.js CI 工作流的触发条件，并通过移除有条件的 TypeScript 和测试阶段来简化构建步骤。
- 新增专用的发布工作流，在创建 release 时构建、测试并将包发布到 npm。

CI：
- 优化 GitHub Actions 配置，将包发布拆分到独立的工作流中，并将主工作流限制为只在 `main` 分支事件上运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows for Node.js builds and package publishing and correct the repository URL metadata.

Enhancements:
- Update the package.json repository URL to point to the new GitHub repository location.

Build:
- Adjust the main Node.js CI workflow triggers and simplify build steps by removing conditional TypeScript and test stages.
- Introduce a dedicated release workflow to build, test, and publish the package to npm on release creation.

CI:
- Refine GitHub Actions configuration by separating package publishing into its own workflow and limiting the primary workflow to main branch events.

</details>