### PR TITLE
fix: Update max_cn_lev to 90

### DIFF
--- a/src/sanae-code/level.ts
+++ b/src/sanae-code/level.ts
@@ -10,7 +10,7 @@ const expLevel: { [key: number]: number } = {
 };
 // 咖啡厅每小时体力生产
 
-const max_cn_lev = 83
+const max_cn_lev = 90
 const max_in_lev = 90
 const max_jp_lev = 90
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 将 CN 的最高等级上限从 83 修正为 90，以符合预期的等级上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the CN maximum level limit from 83 to 90 so it matches the intended cap.

</details>